### PR TITLE
Migrate to NewsData.io API for new sources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,11 +23,13 @@ android {
         multiDexEnabled true
 
         buildConfigField("String", "NEWS_API_KEY", "\"" + localProperties['NEWS_API_KEY'] + "\"")
+        buildConfigField("String", "NEWS_DATA_KEY", "\"" + localProperties['NEWS_DATA_KEY'] + "\"")
     }
 
     buildTypes {
         release {
             resValue("string", "NEWS_API_KEY", localProperties['NEWS_API_KEY'])
+            resValue("string", "NEWS_DATA_KEY", localProperties['NEWS_DATA_KEY'])
 
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/src/main/java/com/example/palexis3/newssum/MainActivity.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/MainActivity.kt
@@ -18,6 +18,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.airbnb.mvrx.compose.mavericksViewModel
+import com.example.palexis3.newssum.composable.HeadlineScreen
+import com.example.palexis3.newssum.composable.ArticleDetailsScreen
+import com.example.palexis3.newssum.composable.NewsSourcesScreen
+import com.example.palexis3.newssum.composable.NewsSourceDetailsScreen
+import com.example.palexis3.newssum.composable.WebViewScreen
 import com.example.palexis3.newssum.navigation.Screen
 import com.example.palexis3.newssum.navigation.bottomNavItems
 import com.example.palexis3.newssum.navigation.navigateSingleTopTo

--- a/app/src/main/java/com/example/palexis3/newssum/composable/ArticleDetailsScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/ArticleDetailsScreen.kt
@@ -21,7 +21,7 @@ import coil.compose.AsyncImage
 import com.example.palexis3.newssum.R
 import com.example.palexis3.newssum.helper.formatToReadableDate
 import com.example.palexis3.newssum.helper.toDate
-import com.example.palexis3.newssum.models.Article
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import com.example.palexis3.newssum.viewmodels.ArticleViewModel
 
 @Composable
@@ -30,7 +30,7 @@ fun ArticleDetailsScreen(
     closeScreen: () -> Unit,
     goToWebView: (String) -> Unit
 ) {
-    val article by remember { articleViewModel.currentArticle }
+    val article by remember { articleViewModel.currentNewsApiArticle }
 
     // Close the screen automatically if the article is null
     article?.let { item ->
@@ -40,14 +40,14 @@ fun ArticleDetailsScreen(
 
 @Composable
 fun ShowArticleState(
-    article: Article,
+    newsApiArticle: NewsApiArticle,
     closeScreen: () -> Unit,
     goToWebView: (String) -> Unit
 ) {
     LazyColumn {
         item {
             Box(Modifier.fillMaxWidth()) {
-                val urlImage = article.urlToImage
+                val urlImage = newsApiArticle.urlToImage
                 if (urlImage != null) {
                     AsyncImage(
                         model = urlImage,
@@ -79,13 +79,13 @@ fun ShowArticleState(
                     .fillMaxWidth()
                     .padding(12.dp)
             ) {
-                val title = article.title
+                val title = newsApiArticle.title
                 if (title != null) {
                     Text(text = title, style = MaterialTheme.typography.titleLarge)
                     Spacer(Modifier.height(12.dp))
                 }
 
-                val publishedAt = article.publishedAt
+                val publishedAt = newsApiArticle.publishedAt
                 if (publishedAt != null) {
                     val date = publishedAt.toDate().formatToReadableDate()
                     Text(
@@ -96,7 +96,7 @@ fun ShowArticleState(
                     Spacer(Modifier.height(2.dp))
                 }
 
-                val newsSource = article.source?.name
+                val newsSource = newsApiArticle.source?.name
                 if (newsSource != null) {
                     val newsSourceText = "News source: $newsSource"
                     Text(
@@ -107,7 +107,7 @@ fun ShowArticleState(
                     Spacer(Modifier.height(2.dp))
                 }
 
-                val author = article.author
+                val author = newsApiArticle.author
                 if (author != null) {
                     val authorText = "Written by: $author"
                     Text(
@@ -118,7 +118,7 @@ fun ShowArticleState(
                     Spacer(Modifier.height(2.dp))
                 }
 
-                val articleUrl = article.url ?: ""
+                val articleUrl = newsApiArticle.url ?: ""
                 if (articleUrl.isNotEmpty()) {
                     Spacer(Modifier.height(4.dp))
                     ElevatedButton(
@@ -132,7 +132,7 @@ fun ShowArticleState(
 
                 Spacer(Modifier.height(20.dp))
 
-                val content = article.content ?: ""
+                val content = newsApiArticle.content ?: ""
                 Box(modifier = Modifier.fillMaxWidth()) {
                     if (content.isNotEmpty()) {
                         Text(text = content, style = MaterialTheme.typography.bodyLarge)

--- a/app/src/main/java/com/example/palexis3/newssum/composable/ArticleDetailsScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/ArticleDetailsScreen.kt
@@ -24,6 +24,8 @@ import com.example.palexis3.newssum.helper.toDate
 import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import com.example.palexis3.newssum.viewmodels.ArticleViewModel
 
+// TODO: Add an article details screen to represent the articles object from the NewsData.io API
+
 @Composable
 fun ArticleDetailsScreen(
     articleViewModel: ArticleViewModel,

--- a/app/src/main/java/com/example/palexis3/newssum/composable/CommonUi.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/CommonUi.kt
@@ -2,31 +2,17 @@ package com.example.palexis3.newssum.composable
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import com.airbnb.mvrx.Fail
-import com.airbnb.mvrx.Loading
-import com.airbnb.mvrx.Success
-import com.example.palexis3.newssum.R
-import com.example.palexis3.newssum.helper.formatToReadableDate
-import com.example.palexis3.newssum.helper.toDate
-import com.example.palexis3.newssum.models.news_api.NewsApiArticle
-import com.example.palexis3.newssum.state.ArticlesState
 
 @Composable
 fun LoadingIcon(modifier: Modifier = Modifier) {
@@ -59,104 +45,6 @@ fun ErrorText(
         style = MaterialTheme.typography.labelMedium,
         fontWeight = FontWeight.Bold
     )
-}
-
-/**
- * The ShowArticleState and ArticleCard composable are in the common section because
- * they will be used in the HeadlineScreen and NewsSourceDetailsScreen
- */
-@Composable
-fun ShowArticlesState(
-    articlesState: ArticlesState,
-    articleSelected: (NewsApiArticle) -> Unit
-) {
-    when (val state = articlesState.articles) {
-        is Loading -> {}
-        is Fail -> {
-            Box {
-                ErrorText(title = R.string.articles_error)
-            }
-        }
-        is Success -> {
-            LazyColumn {
-                val items = state.invoke()
-                if (items.isEmpty()) {
-                    item {
-                        ErrorText(title = R.string.articles_error)
-                    }
-                } else {
-                    items(items, itemContent = { article ->
-                        ArticleCard(
-                            newsApiArticle = article,
-                            articleSelected = articleSelected
-                        )
-                    })
-                }
-            }
-        }
-        else -> {}
-    }
-}
-
-@Composable
-fun ArticleCard(
-    newsApiArticle: NewsApiArticle,
-    articleSelected: (NewsApiArticle) -> Unit
-) {
-    Card(
-        modifier = Modifier
-            .clip(RoundedCornerShape(8.dp))
-            .padding(12.dp)
-            .clickable { articleSelected(newsApiArticle) },
-        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 10.dp)
-    ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            val urlImage = newsApiArticle.urlToImage ?: ""
-            if (urlImage.isNotEmpty()) {
-                AsyncImage(
-                    model = urlImage,
-                    contentDescription = "Headline Image",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(150.dp),
-                    contentScale = ContentScale.Crop,
-                    alignment = Alignment.Center
-                )
-                Spacer(Modifier.height(8.dp))
-            }
-
-            Column(modifier = Modifier.padding(12.dp)) {
-                val title = newsApiArticle.title ?: ""
-                if (title.isNotEmpty()) {
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.ExtraBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Spacer(Modifier.height(4.dp))
-                }
-
-                val publishedAt = newsApiArticle.publishedAt ?: ""
-                if (publishedAt.isNotEmpty()) {
-                    val date = publishedAt.toDate().formatToReadableDate()
-                    Text(text = date, style = MaterialTheme.typography.bodyMedium)
-                    Spacer(Modifier.height(4.dp))
-                }
-
-                val description = newsApiArticle.description ?: ""
-                if (description.isNotEmpty()) {
-                    Text(
-                        text = description,
-                        style = MaterialTheme.typography.bodyMedium,
-                        maxLines = 4,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-            }
-        }
-    }
 }
 
 @Composable

--- a/app/src/main/java/com/example/palexis3/newssum/composable/CommonUi.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/CommonUi.kt
@@ -25,7 +25,7 @@ import com.airbnb.mvrx.Success
 import com.example.palexis3.newssum.R
 import com.example.palexis3.newssum.helper.formatToReadableDate
 import com.example.palexis3.newssum.helper.toDate
-import com.example.palexis3.newssum.models.Article
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import com.example.palexis3.newssum.state.ArticlesState
 
 @Composable
@@ -68,7 +68,7 @@ fun ErrorText(
 @Composable
 fun ShowArticlesState(
     articlesState: ArticlesState,
-    articleSelected: (Article) -> Unit
+    articleSelected: (NewsApiArticle) -> Unit
 ) {
     when (val state = articlesState.articles) {
         is Loading -> {}
@@ -87,7 +87,7 @@ fun ShowArticlesState(
                 } else {
                     items(items, itemContent = { article ->
                         ArticleCard(
-                            article = article,
+                            newsApiArticle = article,
                             articleSelected = articleSelected
                         )
                     })
@@ -100,18 +100,18 @@ fun ShowArticlesState(
 
 @Composable
 fun ArticleCard(
-    article: Article,
-    articleSelected: (Article) -> Unit
+    newsApiArticle: NewsApiArticle,
+    articleSelected: (NewsApiArticle) -> Unit
 ) {
     Card(
         modifier = Modifier
             .clip(RoundedCornerShape(8.dp))
             .padding(12.dp)
-            .clickable { articleSelected(article) },
+            .clickable { articleSelected(newsApiArticle) },
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 10.dp)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            val urlImage = article.urlToImage ?: ""
+            val urlImage = newsApiArticle.urlToImage ?: ""
             if (urlImage.isNotEmpty()) {
                 AsyncImage(
                     model = urlImage,
@@ -126,7 +126,7 @@ fun ArticleCard(
             }
 
             Column(modifier = Modifier.padding(12.dp)) {
-                val title = article.title ?: ""
+                val title = newsApiArticle.title ?: ""
                 if (title.isNotEmpty()) {
                     Text(
                         text = title,
@@ -138,14 +138,14 @@ fun ArticleCard(
                     Spacer(Modifier.height(4.dp))
                 }
 
-                val publishedAt = article.publishedAt ?: ""
+                val publishedAt = newsApiArticle.publishedAt ?: ""
                 if (publishedAt.isNotEmpty()) {
                     val date = publishedAt.toDate().formatToReadableDate()
                     Text(text = date, style = MaterialTheme.typography.bodyMedium)
                     Spacer(Modifier.height(4.dp))
                 }
 
-                val description = article.description ?: ""
+                val description = newsApiArticle.description ?: ""
                 if (description.isNotEmpty()) {
                     Text(
                         text = description,

--- a/app/src/main/java/com/example/palexis3/newssum/composable/HeadlineScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/HeadlineScreen.kt
@@ -132,7 +132,7 @@ fun ShowNewsApiArticlesState(
                     }
                 } else {
                     items(items, itemContent = { article ->
-                        ArticleCard(
+                        NewsApiArticleCard(
                             newsApiArticle = article,
                             articleSelected = articleSelected
                         )
@@ -145,7 +145,7 @@ fun ShowNewsApiArticlesState(
 }
 
 @Composable
-fun ArticleCard(
+fun NewsApiArticleCard(
     newsApiArticle: NewsApiArticle,
     articleSelected: (NewsApiArticle) -> Unit
 ) {

--- a/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourceDetailsScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourceDetailsScreen.kt
@@ -28,12 +28,13 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.compose.collectAsState
 import com.example.palexis3.newssum.R
 import com.example.palexis3.newssum.helper.formatToReadableDate
-import com.example.palexis3.newssum.helper.toDate
+import com.example.palexis3.newssum.helper.toDateEmptySpace
 import com.example.palexis3.newssum.models.news_data.NewsDataArticle
 import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
 import com.example.palexis3.newssum.state.ArticlesState
 import com.example.palexis3.newssum.viewmodels.ArticleViewModel
 import com.example.palexis3.newssum.viewmodels.NewsSourcesViewModel
+import com.google.accompanist.flowlayout.FlowRow
 
 @Composable
 fun NewsSourceDetailsScreen(
@@ -96,9 +97,16 @@ fun ShowNewsSourceDetails(
             Spacer(modifier = Modifier.height(8.dp))
         }
 
-        val category = newsDataNewsSource.category?.get(0) ?: ""
+        val category = newsDataNewsSource.category ?: listOf()
         if (category.isNotEmpty()) {
-            CategoryOutlinedText(category = category)
+            FlowRow {
+                category.forEach { item ->
+                    CategoryOutlinedText(
+                        category = item,
+                        modifier = Modifier.padding(4.dp)
+                    )
+                }
+            }
             Spacer(modifier = Modifier.height(4.dp))
         }
 
@@ -208,7 +216,7 @@ fun NewsDataArticleCard(
 
                 val publishedAt = newsDataArticle.pubDate ?: ""
                 if (publishedAt.isNotEmpty()) {
-                    val date = publishedAt.toDate().formatToReadableDate()
+                    val date = publishedAt.toDateEmptySpace().formatToReadableDate()
                     Text(text = date, style = MaterialTheme.typography.bodyMedium)
                     Spacer(Modifier.height(4.dp))
                 }

--- a/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourceDetailsScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourceDetailsScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.airbnb.mvrx.compose.collectAsState
 import com.example.palexis3.newssum.R
-import com.example.palexis3.newssum.models.Article
-import com.example.palexis3.newssum.models.NewsSource
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
 import com.example.palexis3.newssum.state.ArticlesState
 import com.example.palexis3.newssum.viewmodels.ArticleViewModel
 import com.example.palexis3.newssum.viewmodels.NewsSourcesViewModel
@@ -28,7 +28,7 @@ fun NewsSourceDetailsScreen(
     goToArticleDetailsScreen: () -> Unit,
     goToWebView: (String) -> Unit
 ) {
-    val newsSource by remember { newsSourcesViewModel.currentNewsSource }
+    val newsSource by remember { newsSourcesViewModel.currentNewsApiNewsSource }
 
     newsSource?.let { source ->
         // Get the headline article for this news source
@@ -53,10 +53,10 @@ fun NewsSourceDetailsScreen(
 @Composable
 fun ShowNewsSourceDetails(
     closeScreen: () -> Unit,
-    newsSource: NewsSource,
+    newsApiNewsSource: NewsApiNewsSource,
     articlesState: ArticlesState,
     goToWebView: (String) -> Unit,
-    articleSelected: (Article) -> Unit
+    articleSelected: (NewsApiArticle) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -70,7 +70,7 @@ fun ShowNewsSourceDetails(
             )
         }
 
-        val name = newsSource.name ?: ""
+        val name = newsApiNewsSource.name ?: ""
         if (name.isNotEmpty()) {
             Text(
                 text = name,
@@ -80,13 +80,13 @@ fun ShowNewsSourceDetails(
             Spacer(modifier = Modifier.height(8.dp))
         }
 
-        val description = newsSource.description ?: ""
+        val description = newsApiNewsSource.description ?: ""
         if (description.isNotEmpty()) {
             Text(text = description, style = MaterialTheme.typography.bodyMedium)
             Spacer(modifier = Modifier.height(4.dp))
         }
 
-        val newsSourceUrl = newsSource.url ?: ""
+        val newsSourceUrl = newsApiNewsSource.url ?: ""
         if (newsSourceUrl.isNotEmpty()) {
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourcesScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourcesScreen.kt
@@ -31,9 +31,9 @@ fun NewsSourcesScreen(
     newsSourcesViewModel: NewsSourcesViewModel,
     goToNewsSourcesDetailsScreen: () -> Unit
 ) {
-    var newsSourceCategory by rememberSaveable { mutableStateOf("") }
+    var newsSourceCategory by rememberSaveable { mutableStateOf<String?>(null) }
 
-    LaunchedEffect(key1 = newsSourceCategory) {
+    LaunchedEffect(newsSourceCategory) {
         newsSourcesViewModel.getNewsSources(category = newsSourceCategory)
     }
 

--- a/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourcesScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourcesScreen.kt
@@ -20,7 +20,7 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.compose.collectAsState
 import com.example.palexis3.newssum.R
 import com.example.palexis3.newssum.models.NEWS_API_CATEGORY_TYPES
-import com.example.palexis3.newssum.models.NewsSource
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
 import com.example.palexis3.newssum.state.NewsSourcesState
 import com.example.palexis3.newssum.viewmodels.NewsSourcesViewModel
 import com.google.accompanist.flowlayout.FlowRow
@@ -97,9 +97,9 @@ fun CategoryChipGroup(
 fun ShowNewsSources(
     modifier: Modifier = Modifier,
     newsSourcesState: NewsSourcesState,
-    newsSourceSelected: (NewsSource) -> Unit
+    newsSourceSelected: (NewsApiNewsSource) -> Unit
 ) {
-    when (val state = newsSourcesState.newsSources) {
+    when (val state = newsSourcesState.newsApiNewsSources) {
         is Loading -> {
             Box {
                 LoadingIcon(modifier = Modifier.align(Center))
@@ -135,21 +135,21 @@ fun ShowNewsSources(
 
 @Composable
 fun NewsSourceCard(
-    newsSource: NewsSource,
-    newsSourceSelected: (NewsSource) -> Unit,
+    newsApiNewsSource: NewsApiNewsSource,
+    newsSourceSelected: (NewsApiNewsSource) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
             .padding(bottom = 20.dp)
-            .clickable { newsSourceSelected(newsSource) },
+            .clickable { newsSourceSelected(newsApiNewsSource) },
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 10.dp)
     ) {
         Column(
             Modifier.padding(12.dp)
         ) {
-            val name = newsSource.name ?: ""
+            val name = newsApiNewsSource.name ?: ""
             if (name.isNotEmpty()) {
                 Text(
                     text = name,
@@ -161,7 +161,7 @@ fun NewsSourceCard(
                 Spacer(Modifier.height(4.dp))
             }
 
-            val description = newsSource.description ?: ""
+            val description = newsApiNewsSource.description ?: ""
             if (description.isNotEmpty()) {
                 Text(
                     text = description,

--- a/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourcesScreen.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/composable/NewsSourcesScreen.kt
@@ -14,13 +14,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.compose.collectAsState
 import com.example.palexis3.newssum.R
-import com.example.palexis3.newssum.models.NEWS_API_CATEGORY_TYPES
-import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
+import com.example.palexis3.newssum.models.NEWS_DATA_CATEGORY_TYPES
+import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
 import com.example.palexis3.newssum.state.NewsSourcesState
 import com.example.palexis3.newssum.viewmodels.NewsSourcesViewModel
 import com.google.accompanist.flowlayout.FlowRow
@@ -36,7 +37,7 @@ fun NewsSourcesScreen(
         newsSourcesViewModel.getNewsSources(category = newsSourceCategory)
     }
 
-    val newsSourcesState by newsSourcesViewModel.collectAsState()
+    val newsSourcesState by newsSourcesViewModel.collectAsState(NewsSourcesState::newsDataNewsSources)
 
     Column(modifier = Modifier.fillMaxSize()) {
         TitleHeader(
@@ -73,7 +74,7 @@ fun CategoryChipGroup(
         modifier = Modifier
             .fillMaxWidth().padding(12.dp)
     ) {
-        NEWS_API_CATEGORY_TYPES.forEach { category ->
+        NEWS_DATA_CATEGORY_TYPES.forEach { category ->
             ElevatedSuggestionChip(
                 modifier = Modifier.padding(2.dp),
                 onClick = {
@@ -96,17 +97,17 @@ fun CategoryChipGroup(
 @Composable
 fun ShowNewsSources(
     modifier: Modifier = Modifier,
-    newsSourcesState: NewsSourcesState,
-    newsSourceSelected: (NewsApiNewsSource) -> Unit
+    newsSourcesState: Async<List<NewsDataNewsSource>>,
+    newsSourceSelected: (NewsDataNewsSource) -> Unit
 ) {
-    when (val state = newsSourcesState.newsApiNewsSources) {
+    when (newsSourcesState) {
         is Loading -> {
             Box {
                 LoadingIcon(modifier = Modifier.align(Center))
             }
         }
         is Fail -> {
-            Box {
+            Box(modifier = Modifier.fillMaxWidth()) {
                 ErrorText(
                     modifier = Modifier.align(Center), title = R.string.sources_error
                 )
@@ -114,7 +115,7 @@ fun ShowNewsSources(
         }
         is Success -> {
             LazyColumn(modifier = modifier) {
-                val items = state.invoke()
+                val items = newsSourcesState.invoke()
                 item {
                     if (items.isEmpty()) {
                         ErrorText(title = R.string.sources_error)
@@ -135,38 +136,27 @@ fun ShowNewsSources(
 
 @Composable
 fun NewsSourceCard(
-    newsApiNewsSource: NewsApiNewsSource,
-    newsSourceSelected: (NewsApiNewsSource) -> Unit,
+    newsDataNewsSource: NewsDataNewsSource,
+    newsSourceSelected: (NewsDataNewsSource) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
             .padding(bottom = 20.dp)
-            .clickable { newsSourceSelected(newsApiNewsSource) },
+            .clickable { newsSourceSelected(newsDataNewsSource) },
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 10.dp)
     ) {
         Column(
             Modifier.padding(12.dp)
         ) {
-            val name = newsApiNewsSource.name ?: ""
+            val name = newsDataNewsSource.name ?: ""
             if (name.isNotEmpty()) {
                 Text(
                     text = name,
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.ExtraBold,
                     maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(Modifier.height(4.dp))
-            }
-
-            val description = newsApiNewsSource.description ?: ""
-            if (description.isNotEmpty()) {
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 6,
                     overflow = TextOverflow.Ellipsis
                 )
                 Spacer(Modifier.height(4.dp))

--- a/app/src/main/java/com/example/palexis3/newssum/helper/DateConverter.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/helper/DateConverter.kt
@@ -13,6 +13,10 @@ fun String.toDate(
     return parser.parse(this)
 }
 
+fun String.toDateEmptySpace(
+    dateFormat: String = "yyyy-MM-dd HH:mm:ss"
+) = this.toDate(dateFormat)
+
 /**
  * Utility method that will help convert UTC dates returned from API into readable strings.
  * Reference here: https://stackoverflow.com/a/53714194/3681456

--- a/app/src/main/java/com/example/palexis3/newssum/models/Category.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/Category.kt
@@ -9,3 +9,17 @@ val NEWS_API_CATEGORY_TYPES = listOf(
     "sports",
     "technology"
 )
+
+val NEWS_DATA_CATEGORY_TYPES = listOf(
+    "business",
+    "entertainment",
+    "environment",
+    "food",
+    "health",
+    "politics",
+    "science",
+    "sports",
+    "technology",
+    "top",
+    "world"
+)

--- a/app/src/main/java/com/example/palexis3/newssum/models/news_api/NewsApiArticle.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/news_api/NewsApiArticle.kt
@@ -1,9 +1,9 @@
-package com.example.palexis3.newssum.models
+package com.example.palexis3.newssum.models.news_api
 
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class Article(
+data class NewsApiArticle(
     val author: String?,
     val source: SourceObj?,
     val title: String?,
@@ -20,8 +20,8 @@ data class SourceObj(
     val name: String?
 )
 
-data class HeadlinesResponse(
+data class NewsApiArticlesResponse(
     val status: String,
     val totalResults: Int,
-    val articles: List<Article>
+    val newsApiArticles: List<NewsApiArticle>
 )

--- a/app/src/main/java/com/example/palexis3/newssum/models/news_api/NewsApiNewsSource.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/news_api/NewsApiNewsSource.kt
@@ -1,0 +1,19 @@
+package com.example.palexis3.newssum.models.news_api
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class NewsApiNewsSource(
+    val id: String?,
+    val name: String?,
+    val description: String?,
+    val url: String?,
+    val category: String?,
+    val language: String?,
+    val country: String?
+)
+
+data class NewsApiNewsSourcesResponse(
+    val status: String,
+    val sources: List<NewsApiNewsSource>
+)

--- a/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataArticle.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataArticle.kt
@@ -9,7 +9,8 @@ data class NewsDataArticle(
     val source_id: String?,
     val image_url: String?,
     val description: String?,
-    val content: String?
+    val content: String?,
+    val pubDate: String?
 )
 
 data class NewsDataArticleResponse(

--- a/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataArticle.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataArticle.kt
@@ -1,0 +1,19 @@
+package com.example.palexis3.newssum.models.news_data
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class NewsDataArticle(
+    val title: String?,
+    val link: String?,
+    val source_id: String?,
+    val image_url: String?,
+    val description: String?,
+    val content: String?
+)
+
+data class NewsDataArticleResponse(
+    val status: String,
+    val totalResults: Int,
+    val results: List<NewsDataArticle>
+)

--- a/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataNewsSource.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataNewsSource.kt
@@ -1,19 +1,18 @@
-package com.example.palexis3.newssum.models
+package com.example.palexis3.newssum.models.news_data
 
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class NewsSource(
+data class NewsDataNewsSource(
     val id: String?,
     val name: String?,
-    val description: String?,
     val url: String?,
     val category: String?,
     val language: String?,
     val country: String?
 )
 
-data class NewsSourcesResponse(
+data class NewsDataNewsSourcesResponse(
     val status: String,
-    val sources: List<NewsSource>
+    val results: List<NewsDataNewsSource>
 )

--- a/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataNewsSource.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/models/news_data/NewsDataNewsSource.kt
@@ -7,9 +7,9 @@ data class NewsDataNewsSource(
     val id: String?,
     val name: String?,
     val url: String?,
-    val category: String?,
-    val language: String?,
-    val country: String?
+    val category: List<String>?,
+    val language: List<String>?,
+    val country: List<String>?
 )
 
 data class NewsDataNewsSourcesResponse(

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NetworkModule.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NetworkModule.kt
@@ -15,7 +15,7 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
 private const val NEWS_API_BASE_URL = "https://newsapi.org/"
-private const val NEWS_DATA_BASE_URL = "https://newsdata.io/api/1/"
+private const val NEWS_DATA_BASE_URL = "https://newsdata.io/"
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NetworkModule.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NetworkModule.kt
@@ -15,10 +15,39 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
 private const val NEWS_API_BASE_URL = "https://newsapi.org/"
+private const val NEWS_DATA_BASE_URL = "https://newsdata.io/api/1/"
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+    @Provides
+    @Singleton
+    fun provideNewsData(): NewsData {
+        val moshi = Moshi.Builder()
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+
+        val loggingInterceptor: HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        val authInterceptor = Interceptor { chain ->
+            val headerRequest = chain.request().newBuilder().addHeader("X-ACCESS-KEY", BuildConfig.NEWS_DATA_KEY).build()
+            chain.proceed(headerRequest)
+        }
+        val client: OkHttpClient = OkHttpClient.Builder().apply {
+            addInterceptor(loggingInterceptor)
+            addInterceptor(authInterceptor)
+        }.build()
+
+        return Retrofit.Builder()
+            .baseUrl(NEWS_DATA_BASE_URL)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(client)
+            .build()
+            .create(NewsData::class.java)
+    }
+
     @Provides
     @Singleton
     fun provideNewsApi(): NewsApi {

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NetworkModule.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NetworkModule.kt
@@ -14,7 +14,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
-private const val BASE_URL = "https://newsapi.org/"
+private const val NEWS_API_BASE_URL = "https://newsapi.org/"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -39,7 +39,7 @@ object NetworkModule {
         }.build()
 
         return Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(NEWS_API_BASE_URL)
             .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
             .client(client)
             .build()

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NewsApi.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NewsApi.kt
@@ -1,7 +1,7 @@
 package com.example.palexis3.newssum.networking
 
-import com.example.palexis3.newssum.models.HeadlinesResponse
-import com.example.palexis3.newssum.models.NewsSourcesResponse
+import com.example.palexis3.newssum.models.news_api.NewsApiArticlesResponse
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSourcesResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -11,14 +11,14 @@ interface NewsApi {
     suspend fun getEverything(
         @Query("q") keyword: String?,
         @Query("sortBy") sortBy: String?
-    ): HeadlinesResponse
+    ): NewsApiArticlesResponse
 
     @GET("/v2/top-headlines/sources")
     suspend fun getNewsSources(
         @Query("category") category: String?,
         @Query("language") language: String?,
         @Query("country") country: String?
-    ): NewsSourcesResponse
+    ): NewsApiNewsSourcesResponse
 
     @GET("/v2/top-headlines")
     suspend fun getArticles(
@@ -26,5 +26,5 @@ interface NewsApi {
         @Query("sources") sources: String?,
         @Query("q") keyword: String?,
         @Query("country") country: String?
-    ): HeadlinesResponse
+    ): NewsApiArticlesResponse
 }

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
@@ -9,16 +9,16 @@ interface NewsData {
 
     @GET("/news")
     suspend fun getArticles(
-        @Query("country") country: String,
-        @Query("category") category: String,
-        @Query("language") language: String,
-        @Query("domain") domain: String
+        @Query("country") country: String?,
+        @Query("category") category: String?,
+        @Query("language") language: String?,
+        @Query("domain") domain: String?
     ): NewsDataArticleResponse
 
     @GET("/sources")
     suspend fun getNewsSources(
-        @Query("country") country: String,
-        @Query("category") category: String,
-        @Query("language") language: String
+        @Query("country") country: String?,
+        @Query("category") category: String?,
+        @Query("language") language: String?
     ): NewsDataNewsSourcesResponse
 }

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
@@ -1,0 +1,24 @@
+package com.example.palexis3.newssum.networking
+
+import com.example.palexis3.newssum.models.news_data.NewsDataArticleResponse
+import com.example.palexis3.newssum.models.news_data.NewsDataNewsSourcesResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NewsData {
+
+    @GET("news")
+    suspend fun getArticles(
+        @Query("country") country: String,
+        @Query("category") category: String,
+        @Query("language") language: String,
+        @Query("domain") domain: String
+    ): NewsDataArticleResponse
+
+    @GET("sources")
+    suspend fun getNewsSources(
+        @Query("country") country: String,
+        @Query("category") category: String,
+        @Query("language") language: String
+    ): NewsDataNewsSourcesResponse
+}

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 
 interface NewsData {
 
-    @GET("/news")
+    @GET("/api/1/news")
     suspend fun getArticles(
         @Query("country") country: String?,
         @Query("category") category: String?,
@@ -15,7 +15,7 @@ interface NewsData {
         @Query("domain") domain: String?
     ): NewsDataArticleResponse
 
-    @GET("/sources")
+    @GET("/api/1/sources")
     suspend fun getNewsSources(
         @Query("country") country: String?,
         @Query("category") category: String?,

--- a/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/networking/NewsData.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 
 interface NewsData {
 
-    @GET("news")
+    @GET("/news")
     suspend fun getArticles(
         @Query("country") country: String,
         @Query("category") category: String,
@@ -15,7 +15,7 @@ interface NewsData {
         @Query("domain") domain: String
     ): NewsDataArticleResponse
 
-    @GET("sources")
+    @GET("/sources")
     suspend fun getNewsSources(
         @Query("country") country: String,
         @Query("category") category: String,

--- a/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepository.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepository.kt
@@ -1,15 +1,24 @@
 package com.example.palexis3.newssum.repository.article
 
 import com.example.palexis3.newssum.models.news_api.NewsApiArticle
+import com.example.palexis3.newssum.models.news_data.NewsDataArticle
 import kotlinx.coroutines.flow.Flow
 
 interface ArticleRepository {
-    fun getArticles(
+
+    fun getNewsApiArticles(
         category: String?,
         keyword: String?,
         sources: String?,
         country: String?
     ): Flow<List<NewsApiArticle>>
+
+    fun getNewsDataArticles(
+        country: String?,
+        category: String?,
+        language: String?,
+        domain: String?
+    ): Flow<List<NewsDataArticle>>
 
     fun getEverything(keyword: String?, sortBy: String?): Flow<List<NewsApiArticle>>
 }

--- a/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepository.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepository.kt
@@ -1,6 +1,6 @@
 package com.example.palexis3.newssum.repository.article
 
-import com.example.palexis3.newssum.models.Article
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import kotlinx.coroutines.flow.Flow
 
 interface ArticleRepository {
@@ -9,7 +9,7 @@ interface ArticleRepository {
         keyword: String?,
         sources: String?,
         country: String?
-    ): Flow<List<Article>>
+    ): Flow<List<NewsApiArticle>>
 
-    fun getEverything(keyword: String?, sortBy: String?): Flow<List<Article>>
+    fun getEverything(keyword: String?, sortBy: String?): Flow<List<NewsApiArticle>>
 }

--- a/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepositoryImpl.kt
@@ -1,16 +1,20 @@
 package com.example.palexis3.newssum.repository.article
 
+import android.util.Log
 import com.example.palexis3.newssum.models.news_api.NewsApiArticle
+import com.example.palexis3.newssum.models.news_data.NewsDataArticle
 import com.example.palexis3.newssum.networking.NewsApi
+import com.example.palexis3.newssum.networking.NewsData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class ArticleRepositoryImpl @Inject constructor(
-    private val newsApi: NewsApi
+    private val newsApi: NewsApi,
+    private val newsData: NewsData
 ) : ArticleRepository {
 
-    override fun getArticles(
+    override fun getNewsApiArticles(
         category: String?,
         keyword: String?,
         sources: String?,
@@ -18,8 +22,25 @@ class ArticleRepositoryImpl @Inject constructor(
     ): Flow<List<NewsApiArticle>> =
         flow {
             val response = newsApi.getArticles(category, keyword, sources, country)
+//            Log.d("XXX-SourcesRepository", "country: $country category: $category language: $language response: $response")
             val items = if (response.status == "ok") {
                 response.newsApiArticles
+            } else {
+                listOf()
+            }
+            emit(items)
+        }
+
+    override fun getNewsDataArticles(
+        country: String?,
+        category: String?,
+        language: String?,
+        domain: String?
+    ): Flow<List<NewsDataArticle>> =
+        flow {
+            val response = newsData.getArticles(country, category, language, domain)
+            val items = if (response.status == "success") {
+                response.results
             } else {
                 listOf()
             }

--- a/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.palexis3.newssum.repository.article
 
-import com.example.palexis3.newssum.models.Article
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import com.example.palexis3.newssum.networking.NewsApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -15,11 +15,11 @@ class ArticleRepositoryImpl @Inject constructor(
         keyword: String?,
         sources: String?,
         country: String?
-    ): Flow<List<Article>> =
+    ): Flow<List<NewsApiArticle>> =
         flow {
             val response = newsApi.getArticles(category, keyword, sources, country)
             val items = if (response.status == "ok") {
-                response.articles
+                response.newsApiArticles
             } else {
                 listOf()
             }
@@ -29,11 +29,11 @@ class ArticleRepositoryImpl @Inject constructor(
     override fun getEverything(
         keyword: String?,
         sortBy: String?
-    ): Flow<List<Article>> =
+    ): Flow<List<NewsApiArticle>> =
         flow {
             val response = newsApi.getEverything(keyword, sortBy)
             val items = if (response.status == "ok") {
-                response.articles
+                response.newsApiArticles
             } else {
                 listOf()
             }

--- a/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepositoryImpl.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/article/ArticleRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.example.palexis3.newssum.repository.article
 
-import android.util.Log
 import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import com.example.palexis3.newssum.models.news_data.NewsDataArticle
 import com.example.palexis3.newssum.networking.NewsApi
@@ -22,7 +21,6 @@ class ArticleRepositoryImpl @Inject constructor(
     ): Flow<List<NewsApiArticle>> =
         flow {
             val response = newsApi.getArticles(category, keyword, sources, country)
-//            Log.d("XXX-SourcesRepository", "country: $country category: $category language: $language response: $response")
             val items = if (response.status == "ok") {
                 response.newsApiArticles
             } else {

--- a/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepository.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepository.kt
@@ -1,8 +1,8 @@
 package com.example.palexis3.newssum.repository.source
 
-import com.example.palexis3.newssum.models.NewsSource
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
 import kotlinx.coroutines.flow.Flow
 
 interface NewsSourcesRepository {
-    fun getNewsSources(category: String?, language: String?, country: String?): Flow<List<NewsSource>>
+    fun getNewsSources(category: String?, language: String?, country: String?): Flow<List<NewsApiNewsSource>>
 }

--- a/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepository.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepository.kt
@@ -1,8 +1,8 @@
 package com.example.palexis3.newssum.repository.source
 
-import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
+import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
 import kotlinx.coroutines.flow.Flow
 
 interface NewsSourcesRepository {
-    fun getNewsSources(category: String?, language: String?, country: String?): Flow<List<NewsApiNewsSource>>
+    fun getNewsSources(category: String?, language: String?, country: String?): Flow<List<NewsDataNewsSource>>
 }

--- a/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.example.palexis3.newssum.repository.source
 
-import com.example.palexis3.newssum.models.NewsSource
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
 import com.example.palexis3.newssum.networking.NewsApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -14,7 +14,7 @@ class NewsSourcesRepositoryImpl @Inject constructor(
         category: String?,
         language: String?,
         country: String?
-    ): Flow<List<NewsSource>> =
+    ): Flow<List<NewsApiNewsSource>> =
         flow {
             val response = newsApi.getNewsSources(category, language, country)
             val items = if (response.status == "ok") {

--- a/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.example.palexis3.newssum.repository.source
 
-import android.util.Log
 import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
 import com.example.palexis3.newssum.networking.NewsData
 import kotlinx.coroutines.flow.Flow
@@ -18,7 +17,6 @@ class NewsSourcesRepositoryImpl @Inject constructor(
     ): Flow<List<NewsDataNewsSource>> =
         flow {
             val response = newsData.getNewsSources(country, category, language)
-            Log.d("XXX-SourcesRepository", "country: $country category: $category language: $language response: $response")
             val items = if (response.status == "success") {
                 response.results
             } else {

--- a/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepositoryImpl.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/repository/source/NewsSourcesRepositoryImpl.kt
@@ -1,24 +1,26 @@
 package com.example.palexis3.newssum.repository.source
 
-import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
-import com.example.palexis3.newssum.networking.NewsApi
+import android.util.Log
+import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
+import com.example.palexis3.newssum.networking.NewsData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class NewsSourcesRepositoryImpl @Inject constructor(
-    private val newsApi: NewsApi
+    private val newsData: NewsData
 ) : NewsSourcesRepository {
 
     override fun getNewsSources(
         category: String?,
         language: String?,
         country: String?
-    ): Flow<List<NewsApiNewsSource>> =
+    ): Flow<List<NewsDataNewsSource>> =
         flow {
-            val response = newsApi.getNewsSources(category, language, country)
-            val items = if (response.status == "ok") {
-                response.sources
+            val response = newsData.getNewsSources(country, category, language)
+            Log.d("XXX-SourcesRepository", "country: $country category: $category language: $language response: $response")
+            val items = if (response.status == "success") {
+                response.results
             } else {
                 listOf()
             }

--- a/app/src/main/java/com/example/palexis3/newssum/state/ArticlesState.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/state/ArticlesState.kt
@@ -4,11 +4,16 @@ import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.Uninitialized
 import com.example.palexis3.newssum.models.news_api.NewsApiArticle
+import com.example.palexis3.newssum.models.news_data.NewsDataArticle
 
 /**
- * ArticleState is what will be used to show in the compose screens. And notice in the codebase
- * that this state will be used by the `getHeadlines()` and `getEverything()` screens
+ * newsApiArticles is what will be used to show in the main headline screen. This state will be used
+ * by the `getHeadlines()` and `getEverything()` screens
+ *
+ * newsDataArticles is used to fetch articles when a user goes to the news sources screen and since
+ * we're using a different API, we'll need to have this state encapsulated.
  */
 data class ArticlesState(
-    val articles: Async<List<NewsApiArticle>> = Uninitialized
+    val newsApiArticles: Async<List<NewsApiArticle>> = Uninitialized,
+    val newsDataArticles: Async<List<NewsDataArticle>> = Uninitialized
 ) : MavericksState

--- a/app/src/main/java/com/example/palexis3/newssum/state/ArticlesState.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/state/ArticlesState.kt
@@ -3,12 +3,12 @@ package com.example.palexis3.newssum.state
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.Uninitialized
-import com.example.palexis3.newssum.models.Article
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 
 /**
  * ArticleState is what will be used to show in the compose screens. And notice in the codebase
  * that this state will be used by the `getHeadlines()` and `getEverything()` screens
  */
 data class ArticlesState(
-    val articles: Async<List<Article>> = Uninitialized
+    val articles: Async<List<NewsApiArticle>> = Uninitialized
 ) : MavericksState

--- a/app/src/main/java/com/example/palexis3/newssum/state/NewsSourcesState.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/state/NewsSourcesState.kt
@@ -3,8 +3,8 @@ package com.example.palexis3.newssum.state
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.Uninitialized
-import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
+import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
 
 data class NewsSourcesState(
-    val newsApiNewsSources: Async<List<NewsApiNewsSource>> = Uninitialized
+    val newsDataNewsSources: Async<List<NewsDataNewsSource>> = Uninitialized
 ) : MavericksState

--- a/app/src/main/java/com/example/palexis3/newssum/state/NewsSourcesState.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/state/NewsSourcesState.kt
@@ -3,8 +3,8 @@ package com.example.palexis3.newssum.state
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.Uninitialized
-import com.example.palexis3.newssum.models.NewsSource
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
 
 data class NewsSourcesState(
-    val newsSources: Async<List<NewsSource>> = Uninitialized
+    val newsApiNewsSources: Async<List<NewsApiNewsSource>> = Uninitialized
 ) : MavericksState

--- a/app/src/main/java/com/example/palexis3/newssum/viewmodels/ArticleViewModel.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/viewmodels/ArticleViewModel.kt
@@ -6,6 +6,7 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
 import com.example.palexis3.newssum.models.news_api.NewsApiArticle
+import com.example.palexis3.newssum.models.news_data.NewsDataArticle
 import com.example.palexis3.newssum.repository.article.ArticleRepository
 import com.example.palexis3.newssum.state.ArticlesState
 import dagger.assisted.Assisted
@@ -20,25 +21,43 @@ class ArticleViewModel @AssistedInject constructor(
     var currentNewsApiArticle = mutableStateOf<NewsApiArticle?>(null)
         private set
 
-    fun getArticles(
+    var currentNewsDataArticle = mutableStateOf<NewsDataArticle?>(null)
+        private set
+
+    fun getNewsApiArticles(
+        country: String? = "us",
         category: String? = null,
         keyword: String? = null,
-        sources: String? = null,
-        country: String? = "us"
+        sources: String? = null
     ) {
         articleRepository
-            .getArticles(category, keyword, sources, country)
-            .execute { copy(articles = it) }
+            .getNewsApiArticles(category, keyword, sources, country)
+            .execute { copy(newsApiArticles = it) }
+    }
+
+    fun getNewsDataArticles(
+        country: String? = "us",
+        language: String? = "en",
+        category: String? = null,
+        domain: String? = null
+    ) {
+        articleRepository
+            .getNewsDataArticles(country, category, language, domain)
+            .execute { copy(newsDataArticles = it) }
     }
 
     fun getEverything(keyword: String? = null, sortBy: String? = null) {
         articleRepository
             .getEverything(keyword, sortBy)
-            .execute { copy(articles = it) }
+            .execute { copy(newsApiArticles = it) }
     }
 
-    fun setCurrentArticle(newsApiArticle: NewsApiArticle) {
+    fun setCurrentNewsApiArticle(newsApiArticle: NewsApiArticle) {
         this.currentNewsApiArticle.value = newsApiArticle
+    }
+
+    fun setCurrentNewsDataArticle(newsDataArticle: NewsDataArticle) {
+        this.currentNewsDataArticle.value = newsDataArticle
     }
 
     @AssistedFactory

--- a/app/src/main/java/com/example/palexis3/newssum/viewmodels/ArticleViewModel.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/viewmodels/ArticleViewModel.kt
@@ -5,7 +5,7 @@ import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
-import com.example.palexis3.newssum.models.Article
+import com.example.palexis3.newssum.models.news_api.NewsApiArticle
 import com.example.palexis3.newssum.repository.article.ArticleRepository
 import com.example.palexis3.newssum.state.ArticlesState
 import dagger.assisted.Assisted
@@ -17,7 +17,7 @@ class ArticleViewModel @AssistedInject constructor(
     @Assisted initialState: ArticlesState
 ) : MavericksViewModel<ArticlesState>(initialState) {
 
-    var currentArticle = mutableStateOf<Article?>(null)
+    var currentNewsApiArticle = mutableStateOf<NewsApiArticle?>(null)
         private set
 
     fun getArticles(
@@ -37,8 +37,8 @@ class ArticleViewModel @AssistedInject constructor(
             .execute { copy(articles = it) }
     }
 
-    fun setCurrentArticle(article: Article) {
-        this.currentArticle.value = article
+    fun setCurrentArticle(newsApiArticle: NewsApiArticle) {
+        this.currentNewsApiArticle.value = newsApiArticle
     }
 
     @AssistedFactory

--- a/app/src/main/java/com/example/palexis3/newssum/viewmodels/NewsSourcesViewModel.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/viewmodels/NewsSourcesViewModel.kt
@@ -5,7 +5,7 @@ import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
-import com.example.palexis3.newssum.models.NewsSource
+import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
 import com.example.palexis3.newssum.repository.source.NewsSourcesRepository
 import com.example.palexis3.newssum.state.NewsSourcesState
 import dagger.assisted.Assisted
@@ -17,7 +17,7 @@ class NewsSourcesViewModel @AssistedInject constructor(
     @Assisted initialState: NewsSourcesState
 ) : MavericksViewModel<NewsSourcesState>(initialState) {
 
-    var currentNewsSource = mutableStateOf<NewsSource?>(null)
+    var currentNewsApiNewsSource = mutableStateOf<NewsApiNewsSource?>(null)
         private set
 
     fun getNewsSources(
@@ -27,11 +27,11 @@ class NewsSourcesViewModel @AssistedInject constructor(
     ) {
         sourceRepository
             .getNewsSources(category, language, country)
-            .execute { copy(newsSources = it) }
+            .execute { copy(newsApiNewsSources = it) }
     }
 
-    fun setCurrentNewsSource(newsSource: NewsSource) {
-        this.currentNewsSource.value = newsSource
+    fun setCurrentNewsSource(newsApiNewsSource: NewsApiNewsSource) {
+        this.currentNewsApiNewsSource.value = newsApiNewsSource
     }
 
     @AssistedFactory

--- a/app/src/main/java/com/example/palexis3/newssum/viewmodels/NewsSourcesViewModel.kt
+++ b/app/src/main/java/com/example/palexis3/newssum/viewmodels/NewsSourcesViewModel.kt
@@ -5,7 +5,7 @@ import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
-import com.example.palexis3.newssum.models.news_api.NewsApiNewsSource
+import com.example.palexis3.newssum.models.news_data.NewsDataNewsSource
 import com.example.palexis3.newssum.repository.source.NewsSourcesRepository
 import com.example.palexis3.newssum.state.NewsSourcesState
 import dagger.assisted.Assisted
@@ -13,11 +13,11 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 
 class NewsSourcesViewModel @AssistedInject constructor(
-    private val sourceRepository: NewsSourcesRepository,
+    private val newsSourcesRepository: NewsSourcesRepository,
     @Assisted initialState: NewsSourcesState
 ) : MavericksViewModel<NewsSourcesState>(initialState) {
 
-    var currentNewsApiNewsSource = mutableStateOf<NewsApiNewsSource?>(null)
+    var currentNewsDataNewsSource = mutableStateOf<NewsDataNewsSource?>(null)
         private set
 
     fun getNewsSources(
@@ -25,13 +25,13 @@ class NewsSourcesViewModel @AssistedInject constructor(
         language: String? = "en",
         country: String? = "us"
     ) {
-        sourceRepository
+        newsSourcesRepository
             .getNewsSources(category, language, country)
-            .execute { copy(newsApiNewsSources = it) }
+            .execute { copy(newsDataNewsSources = it) }
     }
 
-    fun setCurrentNewsSource(newsApiNewsSource: NewsApiNewsSource) {
-        this.currentNewsApiNewsSource.value = newsApiNewsSource
+    fun setCurrentNewsSource(newsDataNewsSource: NewsDataNewsSource) {
+        this.currentNewsDataNewsSource.value = newsDataNewsSource
     }
 
     @AssistedFactory


### PR DESCRIPTION
- Added `NewsDataNewsSource` and `NewsDataArticle` models to represent responses from the NewsData.io API
- Refactored the `NewsSourcesScreen` to fetch from NewsData.io instead of NewsApi.org
- Revamped `NewsSourceDetailScreen` to work with the fields from the new `NewsDataNewsSource` object